### PR TITLE
[USERQUEST] 직무별 퀘스트 유저 할당

### DIFF
--- a/myhands/.gitignore
+++ b/myhands/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 application-db.properties
+application-jwt.properties

--- a/myhands/src/main/java/tabom/myhands/common/config/WebConfig.java
+++ b/myhands/src/main/java/tabom/myhands/common/config/WebConfig.java
@@ -17,6 +17,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(jwtInterceptor)
                 .excludePathPatterns("/user/login")
                 .excludePathPatterns("/user/join")
+                .excludePathPatterns("/quest/job")
                 .excludePathPatterns("/");
     }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/controller/QuestController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/controller/QuestController.java
@@ -1,5 +1,6 @@
 package tabom.myhands.domain.quest.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -47,13 +48,15 @@ public class QuestController {
     }
 
     @GetMapping
-    public ResponseEntity<DtoResponse<List<QuestResponse>>> getQuests(@RequestParam Long userId) {
+    public ResponseEntity<DtoResponse<List<QuestResponse>>> getQuests(HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute("userId");
         List<QuestResponse> quests = userQuestService.getQuests(userId);
         return ResponseEntity.ok(new DtoResponse<>(HttpStatus.OK, responseProperties.getSuccess(), quests));
     }
 
     @GetMapping("/completelist")
-    public ResponseEntity<DtoResponse<List<QuestResponse>>> getCompletedQuests(@RequestParam Long userId) {
+    public ResponseEntity<DtoResponse<List<QuestResponse>>> getCompletedQuests(HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute("userId");
         List<QuestResponse> completedQuest = userQuestService.getCompletedQuest(userId);
         return ResponseEntity.ok(new DtoResponse<>(HttpStatus.OK, responseProperties.getSuccess(), completedQuest));
     }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/controller/QuestController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/controller/QuestController.java
@@ -1,15 +1,23 @@
 package tabom.myhands.domain.quest.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import tabom.myhands.common.properties.ResponseProperties;
 import tabom.myhands.common.response.DtoResponse;
 import tabom.myhands.domain.quest.dto.QuestRequest;
+import tabom.myhands.domain.quest.dto.QuestResponse;
+import tabom.myhands.domain.quest.dto.UserQuestRequest;
+import tabom.myhands.domain.quest.dto.UserQuestResponse;
 import tabom.myhands.domain.quest.entity.Quest;
 import tabom.myhands.domain.quest.service.QuestService;
+import tabom.myhands.domain.quest.service.UserQuestService;
 
+import java.util.List;
+
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/quest")
@@ -17,6 +25,7 @@ public class QuestController {
 
     private final ResponseProperties responseProperties;
     private final QuestService questService;
+    private final UserQuestService userQuestService;
 
     @PostMapping
     public ResponseEntity<DtoResponse<Quest>> createQuest(@RequestBody QuestRequest.Create request) {
@@ -30,4 +39,22 @@ public class QuestController {
         return ResponseEntity.ok(new DtoResponse<>(HttpStatus.OK, responseProperties.getSuccess(), quest));
     }
 
+    @PostMapping("/job")
+    public ResponseEntity<DtoResponse<List<UserQuestResponse>>> createWeekCountJobQuest(@RequestBody UserQuestRequest.CreateJobQuest request) {
+        Quest weekCountJobQuest = questService.createWeekCountJobQuest(request.getWeekCount());
+        List<UserQuestResponse> jobQuest = userQuestService.createJobQuest(request.getDepartmentId(), weekCountJobQuest);
+        return ResponseEntity.ok(new DtoResponse<>(HttpStatus.CREATED, responseProperties.getSuccess(), jobQuest));
+    }
+
+    @GetMapping
+    public ResponseEntity<DtoResponse<List<QuestResponse>>> getQuests(@RequestParam Long userId) {
+        List<QuestResponse> quests = userQuestService.getQuests(userId);
+        return ResponseEntity.ok(new DtoResponse<>(HttpStatus.OK, responseProperties.getSuccess(), quests));
+    }
+
+    @GetMapping("/completelist")
+    public ResponseEntity<DtoResponse<List<QuestResponse>>> getCompletedQuests(@RequestParam Long userId) {
+        List<QuestResponse> completedQuest = userQuestService.getCompletedQuest(userId);
+        return ResponseEntity.ok(new DtoResponse<>(HttpStatus.OK, responseProperties.getSuccess(), completedQuest));
+    }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/controller/UserQuestController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/controller/UserQuestController.java
@@ -1,0 +1,28 @@
+package tabom.myhands.domain.quest.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tabom.myhands.common.properties.ResponseProperties;
+import tabom.myhands.common.response.MessageResponse;
+import tabom.myhands.domain.quest.dto.UserQuestRequest;
+import tabom.myhands.domain.quest.service.UserQuestService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user-quest")
+public class UserQuestController {
+
+    private final UserQuestService userQuestService;
+    private final ResponseProperties responseProperties;
+
+    @PostMapping
+    public ResponseEntity<MessageResponse> createUserQuest(@RequestBody UserQuestRequest.Create request) {
+        userQuestService.createUserQuest(request);
+        return ResponseEntity.ok(new MessageResponse(HttpStatus.OK, responseProperties.getSuccess()));
+    }
+}

--- a/myhands/src/main/java/tabom/myhands/domain/quest/dto/QuestResponse.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/dto/QuestResponse.java
@@ -1,0 +1,31 @@
+package tabom.myhands.domain.quest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import tabom.myhands.domain.quest.entity.Quest;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class QuestResponse {
+    private Long questId;
+    private String questType;
+    private String name;
+    private String grade;
+    private Integer expAmount;
+    private Boolean isCompleted;
+    private LocalDateTime completedAt;
+
+    public static QuestResponse from(Quest quest) {
+        return new QuestResponse(
+                quest.getQuestId(),
+                quest.getQuestType(),
+                quest.getName(),
+                quest.getGrade(),
+                quest.getExpAmount(),
+                quest.getIsCompleted(),
+                quest.getCompletedAt()
+        );
+    }
+}

--- a/myhands/src/main/java/tabom/myhands/domain/quest/dto/UserQuestRequest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/dto/UserQuestRequest.java
@@ -1,0 +1,16 @@
+package tabom.myhands.domain.quest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserQuestRequest {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Create{
+        private Long userId;
+        private Long questId;
+    }
+}

--- a/myhands/src/main/java/tabom/myhands/domain/quest/dto/UserQuestRequest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/dto/UserQuestRequest.java
@@ -13,4 +13,12 @@ public class UserQuestRequest {
         private Long userId;
         private Long questId;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateJobQuest {
+        private Integer departmentId;
+        private Integer weekCount;
+    }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/dto/UserQuestResponse.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/dto/UserQuestResponse.java
@@ -1,0 +1,19 @@
+package tabom.myhands.domain.quest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import tabom.myhands.domain.quest.entity.UserQuest;
+
+@Getter
+@AllArgsConstructor
+public class UserQuestResponse {
+    private Long userId;
+    private Long questId;
+
+    public static UserQuestResponse from(UserQuest userQuest) {
+        return new UserQuestResponse(
+                userQuest.getUser().getUserId(),
+                userQuest.getQuest().getQuestId()
+        );
+    }
+}

--- a/myhands/src/main/java/tabom/myhands/domain/quest/entity/Quest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/entity/Quest.java
@@ -50,17 +50,4 @@ public class Quest {
         this.isCompleted = isCompleted;
         this.completedAt = completedAt;
     }
-
-    @Override
-    public String toString() {
-        return "Quest{" +
-                "questId=" + questId +
-                ", questType='" + questType + '\'' +
-                ", name='" + name + '\'' +
-                ", grade='" + grade + '\'' +
-                ", expAmount=" + expAmount +
-                ", isCompleted=" + isCompleted +
-                ", completedAt=" + completedAt +
-                '}';
-    }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/entity/Quest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/entity/Quest.java
@@ -34,14 +34,12 @@ public class Quest {
 
     private LocalDateTime completedAt;
 
-    private Quest(String questType, String name) {
-        this.questType = questType;
-        this.name = name;
-        this.isCompleted = false;
-    }
-
     public static Quest build(String questType, String name) {
-        return new Quest(questType, name);
+        return Quest.builder()
+                .questType(questType)
+                .name(name)
+                .isCompleted(false) // 기본값 설정
+                .build();
     }
 
     public void update(String grade, Integer expAmount, Boolean isCompleted, LocalDateTime completedAt) {

--- a/myhands/src/main/java/tabom/myhands/domain/quest/entity/Quest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/entity/Quest.java
@@ -1,8 +1,13 @@
 package tabom.myhands.domain.quest.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
@@ -25,7 +30,6 @@ public class Quest {
 
     private Integer expAmount;
 
-    @ColumnDefault("false")
     private Boolean isCompleted;
 
     private LocalDateTime completedAt;
@@ -33,6 +37,7 @@ public class Quest {
     private Quest(String questType, String name) {
         this.questType = questType;
         this.name = name;
+        this.isCompleted = false;
     }
 
     public static Quest build(String questType, String name) {
@@ -44,5 +49,18 @@ public class Quest {
         this.expAmount = expAmount;
         this.isCompleted = isCompleted;
         this.completedAt = completedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "Quest{" +
+                "questId=" + questId +
+                ", questType='" + questType + '\'' +
+                ", name='" + name + '\'' +
+                ", grade='" + grade + '\'' +
+                ", expAmount=" + expAmount +
+                ", isCompleted=" + isCompleted +
+                ", completedAt=" + completedAt +
+                '}';
     }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/entity/UserQuest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/entity/UserQuest.java
@@ -32,4 +32,13 @@ public class UserQuest {
     public static UserQuest build(User user, Quest quest) {
         return new UserQuest(user, quest);
     }
+
+    @Override
+    public String toString() {
+        return "UserQuest{" +
+                "userQuestId=" + userQuestId +
+                ", user=" + user +
+                ", quest=" + quest +
+                '}';
+    }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/entity/UserQuest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/entity/UserQuest.java
@@ -32,13 +32,4 @@ public class UserQuest {
     public static UserQuest build(User user, Quest quest) {
         return new UserQuest(user, quest);
     }
-
-    @Override
-    public String toString() {
-        return "UserQuest{" +
-                "userQuestId=" + userQuestId +
-                ", user=" + user +
-                ", quest=" + quest +
-                '}';
-    }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/entity/UserQuest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/entity/UserQuest.java
@@ -23,4 +23,13 @@ public class UserQuest {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "quest_id")
     private Quest quest;
+
+    private UserQuest(User user, Quest quest) {
+        this.user = user;
+        this.quest = quest;
+    }
+
+    public static UserQuest build(User user, Quest quest) {
+        return new UserQuest(user, quest);
+    }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/entity/UserQuest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/entity/UserQuest.java
@@ -2,11 +2,13 @@ package tabom.myhands.domain.quest.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import tabom.myhands.domain.user.entity.User;
 
 @Entity
+@Builder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -24,12 +26,10 @@ public class UserQuest {
     @JoinColumn(name = "quest_id")
     private Quest quest;
 
-    private UserQuest(User user, Quest quest) {
-        this.user = user;
-        this.quest = quest;
-    }
-
     public static UserQuest build(User user, Quest quest) {
-        return new UserQuest(user, quest);
+        return UserQuest.builder()
+                .user(user)
+                .quest(quest)
+                .build();
     }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/repository/UserQuestRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/repository/UserQuestRepository.java
@@ -1,6 +1,8 @@
 package tabom.myhands.domain.quest.repository;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import tabom.myhands.domain.quest.entity.UserQuest;
 import tabom.myhands.domain.user.entity.User;
 
@@ -9,4 +11,7 @@ import java.util.List;
 public interface UserQuestRepository extends CrudRepository<UserQuest, Long> {
 
     List<UserQuest> findByUser(User user);
+
+    @Query("SELECT uq FROM UserQuest uq JOIN FETCH uq.quest WHERE uq.user = :user")
+    List<UserQuest> findByUserWithQuest(@Param("user") User user);
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/QuestService.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/QuestService.java
@@ -10,6 +10,8 @@ public interface QuestService {
     
     Quest createQuest(QuestRequest.Create request);
 
+    Quest createWeekCountJobQuest(Integer weekCount);
+
     Quest updateQuest(QuestRequest.Complete request);
 
     List<Quest> getUserQuestList(User user);

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/QuestServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/QuestServiceImpl.java
@@ -1,6 +1,7 @@
 package tabom.myhands.domain.quest.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tabom.myhands.domain.quest.dto.QuestRequest;
@@ -9,14 +10,18 @@ import tabom.myhands.domain.quest.entity.UserQuest;
 import tabom.myhands.domain.quest.repository.QuestRepository;
 import tabom.myhands.domain.user.entity.User;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class QuestServiceImpl implements QuestService {
+
+    static final LocalDateTime START_DATE_TIME = LocalDateTime.of(2025, 1, 5, 0, 0);
 
     private final QuestRepository questRepository;
     private final UserQuestService userQuestService;
@@ -26,6 +31,16 @@ public class QuestServiceImpl implements QuestService {
     public Quest createQuest(QuestRequest.Create request) {
         Quest quest = Quest.build(request.getQuestType(), request.getName());
         return questRepository.save(quest);
+    }
+
+    @Override
+    @Transactional
+    public Quest createWeekCountJobQuest(Integer weekCount) {
+        String questName = String.format("직무별 퀘스트 %d주차", weekCount);
+        Quest quest = createQuest(new QuestRequest.Create("job", questName));
+        LocalDateTime completedDateTime = START_DATE_TIME.plusWeeks(weekCount-1);
+        updateQuest(new QuestRequest.Complete(quest.getQuestId(), "", 0, false, completedDateTime));
+        return quest;
     }
 
     @Override

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestService.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestService.java
@@ -1,6 +1,9 @@
 package tabom.myhands.domain.quest.service;
 
+import tabom.myhands.domain.quest.dto.QuestResponse;
 import tabom.myhands.domain.quest.dto.UserQuestRequest;
+import tabom.myhands.domain.quest.dto.UserQuestResponse;
+import tabom.myhands.domain.quest.entity.Quest;
 import tabom.myhands.domain.quest.entity.UserQuest;
 import tabom.myhands.domain.user.entity.User;
 
@@ -12,4 +15,9 @@ public interface UserQuestService {
 
     UserQuest createUserQuest(UserQuestRequest.Create request);
 
+    List<UserQuestResponse> createJobQuest(Integer departmentId, Quest weekCountJobQuest);
+
+    List<QuestResponse> getQuests(Long userId);
+
+    List<QuestResponse> getCompletedQuest(Long userId);
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestService.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestService.java
@@ -1,5 +1,6 @@
 package tabom.myhands.domain.quest.service;
 
+import tabom.myhands.domain.quest.dto.UserQuestRequest;
 import tabom.myhands.domain.quest.entity.UserQuest;
 import tabom.myhands.domain.user.entity.User;
 
@@ -8,4 +9,7 @@ import java.util.List;
 public interface UserQuestService {
     
     List<UserQuest> getUserQuests(User user);
+
+    UserQuest createUserQuest(UserQuestRequest.Create request);
+
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestServiceImpl.java
@@ -103,7 +103,7 @@ public class UserQuestServiceImpl implements UserQuestService {
 
         User user = optionalUser.get();
         List<QuestResponse> completedQuests = new ArrayList<>();
-        List<UserQuest> userQuests = userQuestRepository.findByUser(user);
+        List<UserQuest> userQuests = userQuestRepository.findByUserWithQuest(user);
         for (UserQuest userQuest : userQuests) {
             Quest quest = userQuest.getQuest();
             if (quest.getIsCompleted()) {

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestServiceImpl.java
@@ -1,21 +1,28 @@
 package tabom.myhands.domain.quest.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tabom.myhands.domain.quest.dto.QuestResponse;
 import tabom.myhands.domain.quest.dto.UserQuestRequest;
+import tabom.myhands.domain.quest.dto.UserQuestResponse;
 import tabom.myhands.domain.quest.entity.Quest;
 import tabom.myhands.domain.quest.entity.UserQuest;
 import tabom.myhands.domain.quest.repository.QuestRepository;
 import tabom.myhands.domain.quest.repository.UserQuestRepository;
+import tabom.myhands.domain.user.entity.Department;
 import tabom.myhands.domain.user.entity.User;
+import tabom.myhands.domain.user.repository.DepartmentRepository;
 import tabom.myhands.domain.user.repository.UserRepository;
 import tabom.myhands.error.errorcode.UserErrorCode;
 import tabom.myhands.error.exception.UserApiException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -24,6 +31,7 @@ public class UserQuestServiceImpl implements UserQuestService {
     private final UserRepository userRepository;
     private final QuestRepository questRepository;
     private final UserQuestRepository userQuestRepository;
+    private final DepartmentRepository departmentRepository;
 
     @Override
     public List<UserQuest> getUserQuests(User user) {
@@ -50,5 +58,58 @@ public class UserQuestServiceImpl implements UserQuestService {
         UserQuest userQuest = UserQuest.build(user, quest);
 
         return userQuestRepository.save(userQuest);
+    }
+
+    @Override
+    @Transactional
+    public List<UserQuestResponse> createJobQuest(Integer departmentId, Quest weekCountJobQuest) {
+        Optional<Department> optionalDepartment = departmentRepository.findDepartmentByDepartmentId(departmentId);
+        if (optionalDepartment.isEmpty()) {
+            throw new IllegalArgumentException("No department found");
+        }
+
+        List<UserQuestResponse> response = new ArrayList<>();
+        List<User> usersByDepartment = userRepository.findUsersByDepartment(optionalDepartment.get());
+        for (User user : usersByDepartment) {
+            UserQuest userQuest = createUserQuest(new UserQuestRequest.Create(user.getUserId(), weekCountJobQuest.getQuestId()));
+            response.add(UserQuestResponse.from(userQuest));
+        }
+        return response;
+    }
+
+    @Override
+    public List<QuestResponse> getQuests(Long userId) {
+        Optional<User> optionalUser = userRepository.findByUserId(userId);
+        if (optionalUser.isEmpty()) {
+            throw new UserApiException(UserErrorCode.USER_ID_NOT_FOUND);
+        }
+
+        User user = optionalUser.get();
+        List<UserQuest> userQuests = getUserQuests(user);
+        List<QuestResponse> quests = new ArrayList<>();
+        for (UserQuest userQuest : userQuests) {
+            quests.add(QuestResponse.from(userQuest.getQuest()));
+        }
+
+        return quests;
+    }
+
+    @Override
+    public List<QuestResponse> getCompletedQuest(Long userId) {
+        Optional<User> optionalUser = userRepository.findByUserId(userId);
+        if (optionalUser.isEmpty()) {
+            throw new UserApiException(UserErrorCode.USER_ID_NOT_FOUND);
+        }
+
+        User user = optionalUser.get();
+        List<QuestResponse> completedQuests = new ArrayList<>();
+        List<UserQuest> userQuests = userQuestRepository.findByUser(user);
+        for (UserQuest userQuest : userQuests) {
+            Quest quest = userQuest.getQuest();
+            if (quest.getIsCompleted()) {
+                completedQuests.add(QuestResponse.from(quest));
+            }
+        }
+        return completedQuests;
     }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestServiceImpl.java
@@ -41,7 +41,6 @@ public class UserQuestServiceImpl implements UserQuestService {
     @Override
     @Transactional
     public UserQuest createUserQuest(UserQuestRequest.Create request) {
-        System.out.println(request.getQuestId() + " " + request.getQuestId());
         Optional<User> optionalUser = userRepository.findByUserId(request.getUserId());
         Optional<Quest> optionalQuest = questRepository.findByQuestId(request.getQuestId());
 

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestServiceImpl.java
@@ -3,21 +3,52 @@ package tabom.myhands.domain.quest.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tabom.myhands.domain.quest.dto.UserQuestRequest;
+import tabom.myhands.domain.quest.entity.Quest;
 import tabom.myhands.domain.quest.entity.UserQuest;
+import tabom.myhands.domain.quest.repository.QuestRepository;
 import tabom.myhands.domain.quest.repository.UserQuestRepository;
 import tabom.myhands.domain.user.entity.User;
+import tabom.myhands.domain.user.repository.UserRepository;
+import tabom.myhands.error.errorcode.UserErrorCode;
+import tabom.myhands.error.exception.UserApiException;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserQuestServiceImpl implements UserQuestService {
 
+    private final UserRepository userRepository;
+    private final QuestRepository questRepository;
     private final UserQuestRepository userQuestRepository;
 
     @Override
     public List<UserQuest> getUserQuests(User user) {
         return userQuestRepository.findByUser(user);
+    }
+
+    @Override
+    @Transactional
+    public UserQuest createUserQuest(UserQuestRequest.Create request) {
+        System.out.println(request.getQuestId() + " " + request.getQuestId());
+        Optional<User> optionalUser = userRepository.findByUserId(request.getUserId());
+        Optional<Quest> optionalQuest = questRepository.findByQuestId(request.getQuestId());
+
+        if (optionalUser.isEmpty()) {
+            throw new UserApiException(UserErrorCode.USER_ID_NOT_FOUND);
+        }
+
+        if (optionalQuest.isEmpty()) {
+            throw new IllegalArgumentException("No quest found");
+        }
+
+        User user = optionalUser.get();
+        Quest quest = optionalQuest.get();
+        UserQuest userQuest = UserQuest.build(user, quest);
+
+        return userQuestRepository.save(userQuest);
     }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/user/repository/DepartmentRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/user/repository/DepartmentRepository.java
@@ -3,5 +3,9 @@ package tabom.myhands.domain.user.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import tabom.myhands.domain.user.entity.Department;
 
+import java.util.Optional;
+
 public interface DepartmentRepository extends JpaRepository<Department, Integer> {
+
+    Optional<Department> findDepartmentByDepartmentId(Integer departmentId);
 }

--- a/myhands/src/main/java/tabom/myhands/domain/user/repository/UserRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/user/repository/UserRepository.java
@@ -3,8 +3,10 @@ package tabom.myhands.domain.user.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import tabom.myhands.domain.user.entity.Department;
 import tabom.myhands.domain.user.entity.User;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -19,5 +21,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsById(String id);
 
     Optional<User> findByUserId(Long userId);
+
+    List<User> findUsersByDepartment(Department department);
 
 }


### PR DESCRIPTION
## PR Description :page_facing_up:
 
### 관련 이슈 번호

- #16 
  
### 주요 변경사항
  
- [x] 생성된 직무별 퀘스트와 유저 연결
- [x] 해당 주차와 해당 부서 정보를 이용한 직무별 퀘스트 생성
  
### 리뷰 요청

- 직무별 퀘스트 시트에서 요청을 보낼 api를 구현했습니다! 주차와 직무를 생성하는 함수 위주로 봐주시면 감사드리겠습니다.
- 각자 맡으신 파트의 함수에 변화가 생긴 부분도 잘 확인해주세요!! 감사합니다 :)
  
### 발생 이슈
  
- https://www.notion.so/naryeong/a952289d33ab4bfa8de3967d6d66d21b
- https://www.notion.so/naryeong/JPA-N-1-2db983272e3049708ef07071567601cf
  
### 관련 스크린샷

![image](https://github.com/user-attachments/assets/287772e5-6eb0-4d59-8346-c1d192190da9)
![image](https://github.com/user-attachments/assets/5db7f6fc-eb2e-4fd6-8a4a-dbba8139440c)

