### PR TITLE
[USERQUEST] 직무별 퀘스트 시트 변경 시 경험치 반영

### DIFF
--- a/myhands/.gitignore
+++ b/myhands/.gitignore
@@ -42,4 +42,3 @@ application-jwt.properties
 
 ### firebase ###
 myhandsFirebaseKey.json
-application-jwt.properties

--- a/myhands/src/main/java/tabom/myhands/domain/quest/controller/QuestController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/controller/QuestController.java
@@ -10,7 +10,6 @@ import tabom.myhands.common.properties.ResponseProperties;
 import tabom.myhands.common.response.DtoResponse;
 import tabom.myhands.domain.quest.dto.QuestRequest;
 import tabom.myhands.domain.quest.dto.QuestResponse;
-import tabom.myhands.domain.quest.dto.UserQuestRequest;
 import tabom.myhands.domain.quest.dto.UserQuestResponse;
 import tabom.myhands.domain.quest.entity.Quest;
 import tabom.myhands.domain.quest.service.QuestService;
@@ -41,10 +40,25 @@ public class QuestController {
     }
 
     @PostMapping("/job")
-    public ResponseEntity<DtoResponse<List<UserQuestResponse>>> createWeekCountJobQuest(@RequestBody UserQuestRequest.CreateJobQuest request) {
-        Quest weekCountJobQuest = questService.createWeekCountJobQuest(request.getWeekCount());
-        List<UserQuestResponse> jobQuest = userQuestService.createJobQuest(request.getDepartmentId(), weekCountJobQuest);
+    public ResponseEntity<DtoResponse<List<UserQuestResponse>>> createWeekCountJobQuest(@RequestBody QuestRequest.JobQuest request) {
+        Quest weekCountJobQuest = questService.createWeekCountJobQuest(request);
+        List<UserQuestResponse> jobQuest = userQuestService.createJobUserQuest(request.getDepartmentName(), request.getJobGroup(), weekCountJobQuest);
         return ResponseEntity.ok(new DtoResponse<>(HttpStatus.CREATED, responseProperties.getSuccess(), jobQuest));
+    }
+
+    @PatchMapping("/job")
+    public ResponseEntity<DtoResponse<QuestResponse>> updateWeekCountJobQuest(@RequestBody QuestRequest.UpdateJobQuest request) {
+        QuestResponse response = questService.updateWeekCountJobQuest(request);
+        return ResponseEntity.ok(new DtoResponse<>(HttpStatus.OK, responseProperties.getSuccess(), response));
+    }
+
+    @GetMapping("/job")
+    public ResponseEntity<DtoResponse<QuestResponse>> getWeekCountJobQuest(@RequestParam String departmentName,
+                                                                           @RequestParam Integer jobGroup,
+                                                                           @RequestParam Integer weekCount) {
+        QuestRequest.JobQuest request = new QuestRequest.JobQuest(departmentName, jobGroup, weekCount);
+        QuestResponse response = questService.getWeekCountJobQuest(request);
+        return ResponseEntity.ok(new DtoResponse<>(HttpStatus.OK, responseProperties.getSuccess(), response));
     }
 
     @GetMapping

--- a/myhands/src/main/java/tabom/myhands/domain/quest/controller/QuestController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/controller/QuestController.java
@@ -10,7 +10,6 @@ import tabom.myhands.common.properties.ResponseProperties;
 import tabom.myhands.common.response.DtoResponse;
 import tabom.myhands.domain.quest.dto.QuestRequest;
 import tabom.myhands.domain.quest.dto.QuestResponse;
-import tabom.myhands.domain.quest.dto.UserQuestResponse;
 import tabom.myhands.domain.quest.entity.Quest;
 import tabom.myhands.domain.quest.service.QuestService;
 import tabom.myhands.domain.quest.service.UserQuestService;
@@ -40,10 +39,10 @@ public class QuestController {
     }
 
     @PostMapping("/job")
-    public ResponseEntity<DtoResponse<List<UserQuestResponse>>> createWeekCountJobQuest(@RequestBody QuestRequest.JobQuest request) {
+    public ResponseEntity<DtoResponse<QuestResponse>> createWeekCountJobQuest(@RequestBody QuestRequest.JobQuest request) {
         Quest weekCountJobQuest = questService.createWeekCountJobQuest(request);
-        List<UserQuestResponse> jobQuest = userQuestService.createJobUserQuest(request.getDepartmentName(), request.getJobGroup(), weekCountJobQuest);
-        return ResponseEntity.ok(new DtoResponse<>(HttpStatus.CREATED, responseProperties.getSuccess(), jobQuest));
+        QuestResponse response = QuestResponse.from(weekCountJobQuest);
+        return ResponseEntity.ok(new DtoResponse<>(HttpStatus.CREATED, responseProperties.getSuccess(), response));
     }
 
     @PatchMapping("/job")

--- a/myhands/src/main/java/tabom/myhands/domain/quest/dto/QuestRequest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/dto/QuestRequest.java
@@ -27,6 +27,28 @@ public class QuestRequest {
         private LocalDateTime completedAt;
     }
 
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class JobQuest {
+        private String departmentName;
+        private Integer jobGroup;
+        private Integer weekCount;
+    }
+
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateJobQuest {
+        private String departmentName;
+        private Integer jobGroup;
+        private Integer weekCount;
+        private String grade;
+        private Integer expAmount;
+    }
+
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor

--- a/myhands/src/main/java/tabom/myhands/domain/quest/dto/UserQuestRequest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/dto/UserQuestRequest.java
@@ -13,12 +13,4 @@ public class UserQuestRequest {
         private Long userId;
         private Long questId;
     }
-
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class CreateJobQuest {
-        private Integer departmentId;
-        private Integer weekCount;
-    }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/entity/Quest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/entity/Quest.java
@@ -1,9 +1,6 @@
 package tabom.myhands.domain.quest.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +21,7 @@ public class Quest {
 
     private String questType;
 
+    @Column(unique = true)
     private String name;
 
     private String grade;

--- a/myhands/src/main/java/tabom/myhands/domain/quest/repository/QuestRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/repository/QuestRepository.java
@@ -1,6 +1,8 @@
 package tabom.myhands.domain.quest.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import tabom.myhands.domain.quest.entity.Quest;
 
 import java.util.Optional;
@@ -8,4 +10,9 @@ import java.util.Optional;
 public interface QuestRepository extends JpaRepository<Quest, Long> {
 
     Optional<Quest> findByQuestId(Long questId);
+
+    @Query("SELECT q FROM Quest q WHERE q.name = CONCAT(:departmentName, ' 직무그룹', :jobGroupNumber, ' ', :weekCount, '주차')")
+    Optional<Quest> findByFormattedName(@Param("departmentName") String departmentName,
+                                        @Param("jobGroupNumber") Integer jobGroupNumber,
+                                        @Param("weekCount") Integer weekCount);
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/repository/QuestRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/repository/QuestRepository.java
@@ -11,8 +11,9 @@ public interface QuestRepository extends JpaRepository<Quest, Long> {
 
     Optional<Quest> findByQuestId(Long questId);
 
-    @Query("SELECT q FROM Quest q WHERE q.name = CONCAT(:departmentName, ' 직무그룹', :jobGroupNumber, ' ', :weekCount, '주차')")
+    @Query(value = "SELECT * FROM quest q WHERE q.name = CONCAT(:departmentName, ' 직무그룹', :jobGroupNumber, ' ', :weekCount, '주차') LIMIT 1", nativeQuery = true)
     Optional<Quest> findByFormattedName(@Param("departmentName") String departmentName,
                                         @Param("jobGroupNumber") Integer jobGroupNumber,
                                         @Param("weekCount") Integer weekCount);
+
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/QuestService.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/QuestService.java
@@ -1,6 +1,7 @@
 package tabom.myhands.domain.quest.service;
 
 import tabom.myhands.domain.quest.dto.QuestRequest;
+import tabom.myhands.domain.quest.dto.QuestResponse;
 import tabom.myhands.domain.quest.entity.Quest;
 import tabom.myhands.domain.user.entity.User;
 
@@ -10,9 +11,13 @@ public interface QuestService {
     
     Quest createQuest(QuestRequest.Create request);
 
-    Quest createWeekCountJobQuest(Integer weekCount);
-
     Quest updateQuest(QuestRequest.Complete request);
 
     List<Quest> getUserQuestList(User user);
+
+    Quest createWeekCountJobQuest(QuestRequest.JobQuest request);
+
+    QuestResponse updateWeekCountJobQuest(QuestRequest.UpdateJobQuest request);
+
+    QuestResponse getWeekCountJobQuest(QuestRequest.JobQuest request);
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/QuestServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/QuestServiceImpl.java
@@ -5,10 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tabom.myhands.domain.quest.dto.QuestRequest;
+import tabom.myhands.domain.quest.dto.QuestResponse;
 import tabom.myhands.domain.quest.entity.Quest;
 import tabom.myhands.domain.quest.entity.UserQuest;
 import tabom.myhands.domain.quest.repository.QuestRepository;
+import tabom.myhands.domain.user.entity.Department;
 import tabom.myhands.domain.user.entity.User;
+import tabom.myhands.domain.user.repository.DepartmentRepository;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -25,6 +28,7 @@ public class QuestServiceImpl implements QuestService {
 
     private final QuestRepository questRepository;
     private final UserQuestService userQuestService;
+    private final DepartmentRepository departmentRepository;
 
     @Override
     @Transactional
@@ -35,12 +39,44 @@ public class QuestServiceImpl implements QuestService {
 
     @Override
     @Transactional
-    public Quest createWeekCountJobQuest(Integer weekCount) {
-        String questName = String.format("직무별 퀘스트 %d주차", weekCount);
+    public Quest createWeekCountJobQuest(QuestRequest.JobQuest request) {
+        Optional<Department> optionalDepartment = departmentRepository.findDepartmentByName(request.getDepartmentName());
+        if (optionalDepartment.isEmpty()) {
+            throw new IllegalArgumentException("Department not found");
+        }
+
+        String questName = String.format(request.getDepartmentName() + " 직무그룹%d %d주차", request.getJobGroup(), request.getWeekCount());
         Quest quest = createQuest(new QuestRequest.Create("job", questName));
-        LocalDateTime completedDateTime = START_DATE_TIME.plusWeeks(weekCount-1);
+        LocalDateTime completedDateTime = START_DATE_TIME.plusWeeks(request.getWeekCount()-1);
         updateQuest(new QuestRequest.Complete(quest.getQuestId(), "", 0, false, completedDateTime));
+        userQuestService.createJobUserQuest(request.getDepartmentName(), request.getJobGroup(), quest);
         return quest;
+    }
+
+    @Override
+    @Transactional
+    public QuestResponse getWeekCountJobQuest(QuestRequest.JobQuest request) {
+        Optional<Quest> optionalQuest = questRepository.findByFormattedName(request.getDepartmentName(), request.getJobGroup(), request.getWeekCount());
+        if (optionalQuest.isEmpty()) {
+            log.error("Quest not found");
+            Quest quest = createWeekCountJobQuest(request);
+            return QuestResponse.from(quest);
+        }
+        Quest quest = optionalQuest.get();
+        return QuestResponse.from(quest);
+    }
+
+    @Override
+    @Transactional
+    public QuestResponse updateWeekCountJobQuest(QuestRequest.UpdateJobQuest request) {
+        Optional<Quest> optionalQuest = questRepository.findByFormattedName(request.getDepartmentName(), request.getJobGroup(), request.getWeekCount());
+        if (optionalQuest.isEmpty()) {
+            throw new IllegalArgumentException("Quest not found");
+        }
+        Quest quest = optionalQuest.get();
+        LocalDateTime completedDateTime = START_DATE_TIME.plusWeeks(request.getWeekCount()-1);
+        quest.update(request.getGrade(), request.getExpAmount(), true, completedDateTime);
+        return QuestResponse.from(quest);
     }
 
     @Override

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/QuestServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/QuestServiceImpl.java
@@ -40,6 +40,15 @@ public class QuestServiceImpl implements QuestService {
     @Override
     @Transactional
     public Quest createWeekCountJobQuest(QuestRequest.JobQuest request) {
+        Optional<Quest> existingQuest = questRepository.findByFormattedName(
+                request.getDepartmentName(),
+                request.getJobGroup(),
+                request.getWeekCount()
+        );
+        if (existingQuest.isPresent()) {
+            return existingQuest.get(); // 이미 존재하면 새로 생성하지 않고 반환
+        }
+
         Optional<Department> optionalDepartment = departmentRepository.findDepartmentByName(request.getDepartmentName());
         if (optionalDepartment.isEmpty()) {
             throw new IllegalArgumentException("Department not found");

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestService.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestService.java
@@ -15,7 +15,7 @@ public interface UserQuestService {
 
     UserQuest createUserQuest(UserQuestRequest.Create request);
 
-    List<UserQuestResponse> createJobQuest(Integer departmentId, Quest weekCountJobQuest);
+    List<UserQuestResponse> createJobUserQuest(String departmentName, Integer jobGroup, Quest weekCountJobQuest);
 
     List<QuestResponse> getQuests(Long userId);
 

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/UserQuestServiceImpl.java
@@ -61,14 +61,14 @@ public class UserQuestServiceImpl implements UserQuestService {
 
     @Override
     @Transactional
-    public List<UserQuestResponse> createJobQuest(Integer departmentId, Quest weekCountJobQuest) {
-        Optional<Department> optionalDepartment = departmentRepository.findDepartmentByDepartmentId(departmentId);
+    public List<UserQuestResponse> createJobUserQuest(String departmentName, Integer jobGroup, Quest weekCountJobQuest) {
+        Optional<Department> optionalDepartment = departmentRepository.findDepartmentByName(departmentName);
         if (optionalDepartment.isEmpty()) {
             throw new IllegalArgumentException("No department found");
         }
 
         List<UserQuestResponse> response = new ArrayList<>();
-        List<User> usersByDepartment = userRepository.findUsersByDepartment(optionalDepartment.get());
+        List<User> usersByDepartment = userRepository.findUsersByDepartmentAndJobGroup(optionalDepartment.get(), jobGroup);
         for (User user : usersByDepartment) {
             UserQuest userQuest = createUserQuest(new UserQuestRequest.Create(user.getUserId(), weekCountJobQuest.getQuestId()));
             response.add(UserQuestResponse.from(userQuest));

--- a/myhands/src/main/java/tabom/myhands/domain/user/repository/DepartmentRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/user/repository/DepartmentRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface DepartmentRepository extends JpaRepository<Department, Integer> {
 
     Optional<Department> findDepartmentByDepartmentId(Integer departmentId);
+
+    Optional<Department> findDepartmentByName(String departmentName);
 }

--- a/myhands/src/main/java/tabom/myhands/domain/user/repository/UserRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/user/repository/UserRepository.java
@@ -30,4 +30,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmployeeNum(Integer num);
 
     List<User> findAll();
+
+    List<User> findUsersByDepartmentAndJobGroup(Department department, Integer jobGroup);
 }


### PR DESCRIPTION
- 소속, 직무그룹, 주차에 해당하는 시트 내 경험치 값 반영

## PR Description :page_facing_up:
 
### 관련 이슈 번호

- #33 
  
### 주요 변경사항
  
- [x] 시트 내 조건 만족 시 patch 요청
- [x] 직무, 주차에 맞는 quest 탐색 후 반영
  
### 리뷰 요청

- (부서 이름, 직무 그룹, 주차)에 해당하는 직무별 퀘스트 경험치 반영을 하였습니다.
- 시트 내 트리거에서 지정한 위치에 값이 변하고 경험치가 부여됐을 때, 퀘스트를 생성하고 해당 부서와 직무에 해당하는 유저와 퀘스트 간의 연결까지 진행하였습니다.

- 서비스 내에서 다른 서비스를 호출하는 작업들이 많고, 컨트롤러가 많이 복잡해졌습니다.. 이 부분에 대해 피드백 부탁드립니다!

### 발생 이슈
  
- 시트에서 drag와 같은 영역 수정은 edit으로 인식하지 못하고, Enter를 통한 수정이 발생한 부분에 대해서만 edit으로 인식하고 있습니다. 이 부분에 대해서 추후에 고민해보겠습니다.

### 관련 스크린샷

### [직무별 퀘스트 생성]
![image](https://github.com/user-attachments/assets/f2a794c4-d58e-4921-856f-018b41fed482)
![image](https://github.com/user-attachments/assets/8c2edfa0-44e2-4fcf-9557-cb7d2ffa9ef8)

### [매출, 인건비 입력]
![image](https://github.com/user-attachments/assets/579aa9cc-bd7e-46fa-a131-ab0bda85cc28)

### [생성 완료]
![image](https://github.com/user-attachments/assets/5eccb99f-e973-4475-a03a-49848c96d0b9)
![image](https://github.com/user-attachments/assets/9b8be469-0c7e-469a-99f8-4d71cd8ae73b)