### PR TITLE
[ALARM] 푸쉬 알람, 알람 전체 삭제, 알람 전체 조회 기능 구현

### DIFF
--- a/myhands/.gitignore
+++ b/myhands/.gitignore
@@ -36,5 +36,10 @@ out/
 ### VS Code ###
 .vscode/
 
+### properties ###
 application-db.properties
+application-jwt.properties
+
+### firebase ###
+myhandsFirebaseKey.json
 application-jwt.properties

--- a/myhands/build.gradle
+++ b/myhands/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
 
+	implementation 'com.google.firebase:firebase-admin:9.4.2'
+
 }
 
 tasks.named('test') {

--- a/myhands/src/main/java/tabom/myhands/common/config/FirebaseConfig.java
+++ b/myhands/src/main/java/tabom/myhands/common/config/FirebaseConfig.java
@@ -1,0 +1,30 @@
+package tabom.myhands.common.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.InputStream;
+
+
+@Configuration
+public class FirebaseConfig {
+    @PostConstruct
+    public void init(){
+        try{
+            InputStream serviceAccount = new ClassPathResource("myhandsFirebaseKey.json").getInputStream();
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) { // FirebaseApp이 이미 초기화되어 있지 않은 경우에만 초기화 실행
+                FirebaseApp.initializeApp(options);
+            }
+        } catch (Exception e){
+            e.printStackTrace();
+        }
+    }
+}

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/controller/AlarmController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/controller/AlarmController.java
@@ -2,6 +2,7 @@ package tabom.myhands.domain.alarm.controller;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
 import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,14 +21,14 @@ public class AlarmController {
     private final AlarmService alarmService;
 
     @DeleteMapping("")
-    public ResponseEntity<MessageResponse> delete(ServletRequest servletRequest) {
-        alarmService.deleteAlarm((Long) servletRequest.getAttribute("userId"));
+    public ResponseEntity<MessageResponse> delete(HttpServletRequest request) {
+        alarmService.deleteAlarm((Long) request.getAttribute("userId"));
         return ResponseEntity.status(HttpStatus.OK).body(MessageResponse.of(HttpStatus.OK, responseProperties.getSuccess()));
     }
 
     @GetMapping("")
-    public ResponseEntity<DtoResponse<AlarmResponse.AlarmList>> list(ServletRequest servletRequest) {
-        AlarmResponse.AlarmList response = alarmService.getAlarmList((Long) servletRequest.getAttribute("userId"));
+    public ResponseEntity<DtoResponse<AlarmResponse.AlarmList>> list(HttpServletRequest request) {
+        AlarmResponse.AlarmList response = alarmService.getAlarmList((Long) request.getAttribute("userId"));
 
         if(response == null) {
             ResponseEntity.status(HttpStatus.OK).body(DtoResponse.of(HttpStatus.OK, responseProperties.getFail(),null));

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/controller/AlarmController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/controller/AlarmController.java
@@ -36,10 +36,4 @@ public class AlarmController {
         return ResponseEntity.status(HttpStatus.OK).body(DtoResponse.of(HttpStatus.OK, responseProperties.getSuccess(),response));
     }
 
-//    @GetMapping("")
-//    public ResponseEntity<MessageResponse> testAlarm() throws FirebaseMessagingException {
-//        alarmService.sendMessage("f_9TvC02n0dFlU6d1viTFs:APA91bFcEfGNSJ84vkLSNQ3eecjD0owD49uRagkFzWh0V413_eQVeceJmY-tbz-zS8Sovrd0dR0zoLWxw9-BWQCDRUf1ap_UxR_EFXu0pFpybDPgSGQmcTQ",
-//                "푸쉬푸쉬 테스트", "푸쉬푸쉬 베이베 내 푸쉬 받아줘");
-//        return ResponseEntity.status(HttpStatus.OK).body(MessageResponse.of(HttpStatus.OK, responseProperties.getSuccess()));
-//    }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/controller/AlarmController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/controller/AlarmController.java
@@ -1,7 +1,5 @@
 package tabom.myhands.domain.alarm.controller;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
-import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,7 +13,7 @@ import tabom.myhands.domain.alarm.service.AlarmService;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("alarm")
+@RequestMapping("/alarm")
 public class AlarmController {
     private final ResponseProperties responseProperties;
     private final AlarmService alarmService;

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/controller/AlarmController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/controller/AlarmController.java
@@ -1,0 +1,44 @@
+package tabom.myhands.domain.alarm.controller;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import jakarta.servlet.ServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import tabom.myhands.common.properties.ResponseProperties;
+import tabom.myhands.common.response.DtoResponse;
+import tabom.myhands.common.response.MessageResponse;
+import tabom.myhands.domain.alarm.dto.AlarmResponse;
+import tabom.myhands.domain.alarm.service.AlarmService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("alarm")
+public class AlarmController {
+    private final ResponseProperties responseProperties;
+    private final AlarmService alarmService;
+
+    @DeleteMapping("")
+    public ResponseEntity<MessageResponse> delete(ServletRequest servletRequest) {
+        alarmService.deleteAlarm((Long) servletRequest.getAttribute("userId"));
+        return ResponseEntity.status(HttpStatus.OK).body(MessageResponse.of(HttpStatus.OK, responseProperties.getSuccess()));
+    }
+
+    @GetMapping("")
+    public ResponseEntity<DtoResponse<AlarmResponse.AlarmList>> list(ServletRequest servletRequest) {
+        AlarmResponse.AlarmList response = alarmService.getAlarmList((Long) servletRequest.getAttribute("userId"));
+
+        if(response == null) {
+            ResponseEntity.status(HttpStatus.OK).body(DtoResponse.of(HttpStatus.OK, responseProperties.getFail(),null));
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(DtoResponse.of(HttpStatus.OK, responseProperties.getSuccess(),response));
+    }
+
+//    @GetMapping("")
+//    public ResponseEntity<MessageResponse> testAlarm() throws FirebaseMessagingException {
+//        alarmService.sendMessage("f_9TvC02n0dFlU6d1viTFs:APA91bFcEfGNSJ84vkLSNQ3eecjD0owD49uRagkFzWh0V413_eQVeceJmY-tbz-zS8Sovrd0dR0zoLWxw9-BWQCDRUf1ap_UxR_EFXu0pFpybDPgSGQmcTQ",
+//                "푸쉬푸쉬 테스트", "푸쉬푸쉬 베이베 내 푸쉬 받아줘");
+//        return ResponseEntity.status(HttpStatus.OK).body(MessageResponse.of(HttpStatus.OK, responseProperties.getSuccess()));
+//    }
+}

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/dto/AlarmResponse.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/dto/AlarmResponse.java
@@ -1,0 +1,47 @@
+package tabom.myhands.domain.alarm.dto;
+
+import lombok.*;
+import tabom.myhands.domain.alarm.entity.Alarm;
+import tabom.myhands.domain.user.dto.UserResponse;
+
+import java.util.List;
+
+public class AlarmResponse {
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class CreateAlarm {
+        private boolean category;
+        private String createdAt;
+        private String title;
+        private Long boardId;
+        private int exp;
+
+        public static AlarmResponse.CreateAlarm build(Alarm alarm, String createdAt){
+            return CreateAlarm.builder()
+                    .category(alarm.isCategory())
+                    .createdAt(createdAt)
+                    .title(alarm.getTitle())
+                    .boardId(alarm.getBoardId())
+                    .exp(alarm.getExp())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AlarmList {
+        private List<CreateAlarm> recentAlarmList;
+        private List<CreateAlarm> oldAlarmList;
+
+        public static AlarmResponse.AlarmList build(List<CreateAlarm> recentAlarmList, List<CreateAlarm> oldAlarmList) {
+            return AlarmList.builder()
+                    .recentAlarmList(recentAlarmList)
+                    .oldAlarmList(oldAlarmList)
+                    .build();
+        }
+    }
+}

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/dto/AlarmResponse.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/dto/AlarmResponse.java
@@ -2,7 +2,6 @@ package tabom.myhands.domain.alarm.dto;
 
 import lombok.*;
 import tabom.myhands.domain.alarm.entity.Alarm;
-import tabom.myhands.domain.user.dto.UserResponse;
 
 import java.util.List;
 

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/entity/Alarm.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/entity/Alarm.java
@@ -1,0 +1,72 @@
+package tabom.myhands.domain.alarm.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import tabom.myhands.domain.quest.entity.Quest;
+import tabom.myhands.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "alarm")
+public class Alarm {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="alarm_id", nullable = false)
+    private Long alarmId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private boolean category;
+
+    private Long boardId;
+
+    private int exp;
+
+    @Column(name = "created_at", updatable = false, nullable = false, columnDefinition = "DATETIME")
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+        public static Alarm BoardAlarmCreate(String title, Long boardId, User user){
+        return Alarm.builder()
+                .user(user)
+                .title(title)
+                .category(true)
+                .boardId(boardId)
+                .build();
+    }
+
+//    public static Alarm BoardAlarmCreate(Board board, User user){
+//        return Alarm.builder()
+//                .user(user)
+//                .title(board.getTitle())
+//                .category(true)
+//                .boardId(board.getBoardId())
+//                .build();
+//    }
+
+        public static Alarm ExpAlarmCreate(Quest quest, User user) {
+            String title = quest.getName() + "!";
+
+            return Alarm.builder()
+                .user(user)
+                .title(title)
+                .category(false)
+                .exp(quest.getExpAmount())
+                .build();
+    }
+}

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/entity/Alarm.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/entity/Alarm.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import tabom.myhands.domain.board.entity.Board;
 import tabom.myhands.domain.quest.entity.Quest;
 import tabom.myhands.domain.user.entity.User;
 
@@ -41,28 +42,19 @@ public class Alarm {
     @CreatedDate
     private LocalDateTime createdAt;
 
-        public static Alarm BoardAlarmCreate(String title, Long boardId, User user){
+    public static Alarm BoardAlarmCreate(Board board, User user){
         return Alarm.builder()
                 .user(user)
-                .title(title)
+                .title(board.getTitle())
                 .category(true)
-                .boardId(boardId)
+                .boardId(board.getBoardId())
                 .build();
     }
 
-//    public static Alarm BoardAlarmCreate(Board board, User user){
-//        return Alarm.builder()
-//                .user(user)
-//                .title(board.getTitle())
-//                .category(true)
-//                .boardId(board.getBoardId())
-//                .build();
-//    }
+    public static Alarm ExpAlarmCreate(Quest quest, User user) {
+        String title = quest.getName() + "!";
 
-        public static Alarm ExpAlarmCreate(Quest quest, User user) {
-            String title = quest.getName() + "!";
-
-            return Alarm.builder()
+        return Alarm.builder()
                 .user(user)
                 .title(title)
                 .category(false)

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/entity/Alarm.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/entity/Alarm.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import tabom.myhands.domain.board.entity.Board;
 import tabom.myhands.domain.quest.entity.Quest;
 import tabom.myhands.domain.user.entity.User;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "alarm")
 public class Alarm {
     @Id
@@ -42,7 +44,7 @@ public class Alarm {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    public static Alarm BoardAlarmCreate(Board board, User user){
+    public static Alarm BoardAlarmCreate(User user, Board board){
         return Alarm.builder()
                 .user(user)
                 .title(board.getTitle())
@@ -51,7 +53,7 @@ public class Alarm {
                 .build();
     }
 
-    public static Alarm ExpAlarmCreate(Quest quest, User user) {
+    public static Alarm ExpAlarmCreate(User user, Quest quest) {
         String title = quest.getName() + "!";
 
         return Alarm.builder()

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/repository/AlarmRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/repository/AlarmRepository.java
@@ -1,13 +1,18 @@
 package tabom.myhands.domain.alarm.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import tabom.myhands.domain.alarm.entity.Alarm;
 import tabom.myhands.domain.user.entity.User;
 
 import java.util.List;
 
+
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
-//    List<Alarm> findAllByUserOrderByCreateAtDesc(User user);
-    List<Alarm> findAllByUser(User user);
-    void deleteAllByUser(User user);
+    List<Alarm> findAllByUserOrderByCreatedAtDesc(User user);
+    @Modifying
+    @Query("DELETE FROM Alarm a WHERE a.user = :user")
+    void deleteAllByUser(@Param("user") User user);
 }

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/repository/AlarmRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/repository/AlarmRepository.java
@@ -1,0 +1,12 @@
+package tabom.myhands.domain.alarm.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import tabom.myhands.domain.alarm.entity.Alarm;
+import tabom.myhands.domain.user.entity.User;
+
+import java.util.List;
+
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+    List<Alarm> findAllByUserOrderByCreateAtDesc(User user);
+    void deleteAllByUser(User user);
+}

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/repository/AlarmRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/repository/AlarmRepository.java
@@ -7,6 +7,7 @@ import tabom.myhands.domain.user.entity.User;
 import java.util.List;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
-    List<Alarm> findAllByUserOrderByCreateAtDesc(User user);
+//    List<Alarm> findAllByUserOrderByCreateAtDesc(User user);
+    List<Alarm> findAllByUser(User user);
     void deleteAllByUser(User user);
 }

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmService.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmService.java
@@ -1,0 +1,11 @@
+package tabom.myhands.domain.alarm.service;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import tabom.myhands.domain.alarm.dto.AlarmResponse;
+
+public interface AlarmService {
+    void deleteAlarm(Long userId);
+    AlarmResponse.AlarmList getAlarmList(Long userId);
+
+//    void sendMessage(String token, String title, String body) throws FirebaseMessagingException;
+}

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmService.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmService.java
@@ -2,11 +2,13 @@ package tabom.myhands.domain.alarm.service;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
 import tabom.myhands.domain.alarm.dto.AlarmResponse;
-import tabom.myhands.domain.alarm.entity.Alarm;
+import tabom.myhands.domain.board.entity.Board;
+import tabom.myhands.domain.quest.entity.Quest;
 import tabom.myhands.domain.user.entity.User;
 
 public interface AlarmService {
     void deleteAlarm(Long userId);
     AlarmResponse.AlarmList getAlarmList(Long userId);
-    void sendMessage(User user, Alarm alarm) throws FirebaseMessagingException;
+    void createBoardAlarm(Board board) throws FirebaseMessagingException;
+    void createExpAlarm(User user, Quest quest) throws FirebaseMessagingException;
 }

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmService.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmService.java
@@ -2,10 +2,11 @@ package tabom.myhands.domain.alarm.service;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
 import tabom.myhands.domain.alarm.dto.AlarmResponse;
+import tabom.myhands.domain.alarm.entity.Alarm;
+import tabom.myhands.domain.user.entity.User;
 
 public interface AlarmService {
     void deleteAlarm(Long userId);
     AlarmResponse.AlarmList getAlarmList(Long userId);
-
-//    void sendMessage(String token, String title, String body) throws FirebaseMessagingException;
+    void sendMessage(User user, Alarm alarm) throws FirebaseMessagingException;
 }

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmServiceImpl.java
@@ -38,12 +38,12 @@ public class AlarmServiceImpl implements AlarmService {
     @Override
     @Transactional
     public void deleteAlarm(Long userId) {
-        User user = userRepository.findById(userId).get();
+        User user = userRepository.findByUserId(userId).get();
         alarmRepository.deleteAllByUser(user);
     }
 
     public AlarmResponse.AlarmList getAlarmList(Long userId) {
-        User user = userRepository.findById(userId).get();
+        User user = userRepository.findByUserId(userId).get();
         List<AlarmResponse.CreateAlarm> recentList = new ArrayList<>();
         List<AlarmResponse.CreateAlarm> oldList = new ArrayList<>();
 

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmServiceImpl.java
@@ -1,0 +1,123 @@
+package tabom.myhands.domain.alarm.service;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+
+import com.google.firebase.messaging.Notification;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import tabom.myhands.domain.alarm.dto.AlarmResponse;
+import tabom.myhands.domain.alarm.entity.Alarm;
+import tabom.myhands.domain.alarm.repository.AlarmRepository;
+import tabom.myhands.domain.user.entity.User;
+import tabom.myhands.domain.user.repository.UserRepository;
+import tabom.myhands.error.errorcode.UserErrorCode;
+import tabom.myhands.error.exception.UserApiException;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AlarmServiceImpl implements AlarmService {
+    private final AlarmRepository alarmRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public void deleteAlarm(Long userId) {
+        User user = userRepository.findById(userId).get();
+        alarmRepository.deleteAllByUser(user);
+    }
+
+    public AlarmResponse.AlarmList getAlarmList(Long userId) {
+        User user = userRepository.findById(userId).get();
+        List<AlarmResponse.CreateAlarm> recentList = new ArrayList<>();
+        List<AlarmResponse.CreateAlarm> oldList = new ArrayList<>();
+
+        List<Alarm> alarmList = alarmRepository.findAllByUserOrderByCreateAtDesc(user);
+
+        for(Alarm a : alarmList) {
+            boolean lastDay = a.getCreatedAt().isBefore(LocalDate.now().atStartOfDay());
+            String createdAt = formatCreatedAt(a.getCreatedAt(), lastDay);
+            AlarmResponse.CreateAlarm ca = AlarmResponse.CreateAlarm.build(a, createdAt);
+
+            if(lastDay) {
+                oldList.add(ca);
+            } else {
+                recentList.add(ca);
+            }
+        }
+
+        return AlarmResponse.AlarmList.build(recentList, oldList);
+    }
+
+    private String formatCreatedAt(LocalDateTime d, boolean lastDay) {
+        if(lastDay) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy. M. d.");
+            return d.format(formatter);
+        }
+
+        int diffMin = (int) Duration.between(d, LocalDateTime.now()).toMinutes();
+
+        if(diffMin > 60) {
+            return diffMin / 60 + "시간 전";
+        }
+
+        if(diffMin > 10) {
+            return diffMin / 10 + "0분 전";
+        }
+
+        return diffMin + "분 전";
+    }
+
+    /*
+
+    public void sendMessage(String token, String title, String body) throws FirebaseMessagingException {
+//         String message = FirebaseMessaging.getInstance().send(Message.builder()
+//                .setNotification(Notification.builder()
+//                        .setTitle(title)
+//                        .setBody(body)
+//                        .build())
+//                .setToken(token)  // 대상 디바이스의 등록 토큰
+//                .build());
+
+
+        Message message = Message.builder()
+                .setToken(token)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .build();
+
+        String response = FirebaseMessaging.getInstance().send(message);
+        System.out.println("Successfully sent message: " + response);
+    }
+
+    private String getAccessToken() throws IOException {
+        String firebaseConfigPath = "myhandsFirebaseKey.json";
+
+        GoogleCredentials googleCredentials = GoogleCredentials
+                .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
+                .createScoped(List.of("<https://www.googleapis.com/auth/cloud-platform>"));
+
+        googleCredentials.refreshIfExpired();
+        return googleCredentials.getAccessToken().getTokenValue();
+    }
+
+     */
+
+}

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmServiceImpl.java
@@ -16,17 +16,12 @@ import tabom.myhands.domain.alarm.entity.Alarm;
 import tabom.myhands.domain.alarm.repository.AlarmRepository;
 import tabom.myhands.domain.user.entity.User;
 import tabom.myhands.domain.user.repository.UserRepository;
-import tabom.myhands.error.errorcode.UserErrorCode;
-import tabom.myhands.error.exception.UserApiException;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -47,7 +42,8 @@ public class AlarmServiceImpl implements AlarmService {
         List<AlarmResponse.CreateAlarm> recentList = new ArrayList<>();
         List<AlarmResponse.CreateAlarm> oldList = new ArrayList<>();
 
-        List<Alarm> alarmList = alarmRepository.findAllByUserOrderByCreateAtDesc(user);
+        List<Alarm> alarmList = alarmRepository.findAllByUser(user);
+        Collections.sort(alarmList, (o1, o2) -> o1.getCreatedAt().compareTo(o2.getCreatedAt()));
 
         for(Alarm a : alarmList) {
             boolean lastDay = a.getCreatedAt().isBefore(LocalDate.now().atStartOfDay());
@@ -83,20 +79,18 @@ public class AlarmServiceImpl implements AlarmService {
         return diffMin + "분 전";
     }
 
-    /*
 
-    public void sendMessage(String token, String title, String body) throws FirebaseMessagingException {
-//         String message = FirebaseMessaging.getInstance().send(Message.builder()
-//                .setNotification(Notification.builder()
-//                        .setTitle(title)
-//                        .setBody(body)
-//                        .build())
-//                .setToken(token)  // 대상 디바이스의 등록 토큰
-//                .build());
+    public void sendMessage(User user, Alarm alarm) throws FirebaseMessagingException {
+        String title = "공지사항";
+        String body = alarm.getTitle();
 
+        if(!alarm.isCategory()) {
+            title = "경험치 획득";
+            body = body + "\n" + alarm.getExp() + " do를 획득하셨습니다.";
+        }
 
         Message message = Message.builder()
-                .setToken(token)
+                .setToken(user.getDeviceToken())
                 .setNotification(Notification.builder()
                         .setTitle(title)
                         .setBody(body)
@@ -104,20 +98,6 @@ public class AlarmServiceImpl implements AlarmService {
                 .build();
 
         String response = FirebaseMessaging.getInstance().send(message);
-        System.out.println("Successfully sent message: " + response);
     }
-
-    private String getAccessToken() throws IOException {
-        String firebaseConfigPath = "myhandsFirebaseKey.json";
-
-        GoogleCredentials googleCredentials = GoogleCredentials
-                .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
-                .createScoped(List.of("<https://www.googleapis.com/auth/cloud-platform>"));
-
-        googleCredentials.refreshIfExpired();
-        return googleCredentials.getAccessToken().getTokenValue();
-    }
-
-     */
 
 }

--- a/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/alarm/service/AlarmServiceImpl.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 import tabom.myhands.domain.alarm.dto.AlarmResponse;
 import tabom.myhands.domain.alarm.entity.Alarm;
 import tabom.myhands.domain.alarm.repository.AlarmRepository;
+import tabom.myhands.domain.board.entity.Board;
+import tabom.myhands.domain.quest.entity.Quest;
 import tabom.myhands.domain.user.entity.User;
 import tabom.myhands.domain.user.repository.UserRepository;
 import tabom.myhands.error.errorcode.UserErrorCode;
@@ -60,6 +62,26 @@ public class AlarmServiceImpl implements AlarmService {
         return AlarmResponse.AlarmList.build(recentList, oldList);
     }
 
+    @Override
+    @Transactional
+    public void createBoardAlarm(Board board) throws FirebaseMessagingException {
+        List<User> users = userRepository.findAll();
+
+        for(User user : users) {
+            Alarm alarm = Alarm.BoardAlarmCreate(user, board);
+            alarmRepository.save(alarm);
+            sendMessage(user, alarm);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void createExpAlarm(User user, Quest quest) throws FirebaseMessagingException {
+        Alarm alarm = Alarm.ExpAlarmCreate(user, quest);
+        alarmRepository.save(alarm);
+        sendMessage(user, alarm);
+    }
+
     private String formatCreatedAt(LocalDateTime d, boolean lastDay) {
         if(lastDay) {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy. M. d.");
@@ -79,7 +101,6 @@ public class AlarmServiceImpl implements AlarmService {
         return diffMin + "분 전";
     }
 
-    @Override
     public void sendMessage(User user, Alarm alarm) throws FirebaseMessagingException {
         String title = "공지사항";
         String body = alarm.getTitle();

--- a/myhands/src/main/java/tabom/myhands/domain/board/controller/BoardController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/board/controller/BoardController.java
@@ -1,5 +1,6 @@
 package tabom.myhands.domain.board.controller;
 
+import com.google.firebase.messaging.FirebaseMessagingException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,7 +24,7 @@ public class BoardController {
     private final ResponseProperties responseProperties;
 
     @PostMapping("/create")
-    public ResponseEntity<MessageResponse> create(HttpServletRequest request, @RequestBody BoardRequest.Create requestDto) {
+    public ResponseEntity<MessageResponse> create(HttpServletRequest request, @RequestBody BoardRequest.Create requestDto) throws FirebaseMessagingException {
         Long userId = (Long) request.getAttribute("userId");
         boolean isAdmin = (boolean) request.getAttribute("isAdmin");
         boardService.create(userId, isAdmin, requestDto);

--- a/myhands/src/main/java/tabom/myhands/domain/board/service/BoardService.java
+++ b/myhands/src/main/java/tabom/myhands/domain/board/service/BoardService.java
@@ -1,12 +1,13 @@
 package tabom.myhands.domain.board.service;
 
+import com.google.firebase.messaging.FirebaseMessagingException;
 import tabom.myhands.domain.board.dto.BoardRequest;
 import tabom.myhands.domain.board.dto.BoardResponse;
 
 import java.util.List;
 
 public interface BoardService {
-    void create(Long userId, boolean isAdmin, BoardRequest.Create requestDto);
+    void create(Long userId, boolean isAdmin, BoardRequest.Create requestDto) throws FirebaseMessagingException;
     void edit(Long userId, boolean isAdmin, BoardRequest.Edit requestDto);
     void delete(boolean isAdmin, Long boardId);
     BoardResponse.Detail detail(Long boardId);

--- a/myhands/src/main/java/tabom/myhands/domain/user/dto/UserRequest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/user/dto/UserRequest.java
@@ -29,6 +29,7 @@ public class UserRequest {
     public static class Login{
         private String id;
         private String password;
+        private String deviceToken;
     }
 
     @Getter

--- a/myhands/src/main/java/tabom/myhands/domain/user/entity/User.java
+++ b/myhands/src/main/java/tabom/myhands/domain/user/entity/User.java
@@ -75,6 +75,10 @@ public class User {
                 .build();
     }
 
+    public void changeDeviceToken(String deviceToken) {
+        this.deviceToken = deviceToken;
+    }
+
     public void changePassword(String newPassword) {
         if (newPassword == null || newPassword.isEmpty()) {
             throw new UserApiException(UserErrorCode.PASSWORD_CANNOT_BE_EMPTY);

--- a/myhands/src/main/java/tabom/myhands/domain/user/repository/UserRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/user/repository/UserRepository.java
@@ -28,4 +28,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findAllUser();
 
     boolean existsByEmployeeNum(Integer num);
+
+    List<User> findAll();
 }

--- a/myhands/src/main/java/tabom/myhands/domain/user/service/UserServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/user/service/UserServiceImpl.java
@@ -88,6 +88,8 @@ public class UserServiceImpl implements UserService{
             if (!user.getPassword().equals(request.getPassword())) {
                 throw new UserApiException(UserErrorCode.LOGIN_FAILED);
             }
+            user.changeDeviceToken(request.getDeviceToken());
+            userRepository.save(user);
         }
 
         Long userId = isAdmin ? adminOptional.get().getAdminId() : userOptional.get().getUserId();


### PR DESCRIPTION
## PR Description :page_facing_up:
 
### 관련 이슈 번호

- #9, #19
  
### 주요 변경사항
  
- [x] 푸쉬 알람 기능 구현
- [x] 알람 전체 삭제 기능 구현
- [x] 알람 전체 조회 기능 구현
  
### 리뷰 요청

- 유저 로그인에 디바이스토큰 저장이 추가되었습니다.
- 게시글 생성 시 모든 유저에게 알람이 생기고 푸쉬 알림이 전송됩니다.
- 경험치 생성 시 해당 유저에게 알람이 가는 메서드와 알람 엔티티가 저장되는 메서드는 퀘스트와 연결하지 않아서 존재만 하고 작동하지 않습니다.
- 유저 레포지토리 32번째 줄에 코드 작성해서 충돌 가능성 있습니다.