### PR TITLE
[USERQUEST] 리더부여 퀘스트 시트 변경 시 퀘스트 생성 및 경험치 반영

### DIFF
--- a/myhands/src/main/java/tabom/myhands/common/config/WebConfig.java
+++ b/myhands/src/main/java/tabom/myhands/common/config/WebConfig.java
@@ -17,6 +17,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(jwtInterceptor)
                 .excludePathPatterns("/user/login")
                 .excludePathPatterns("/quest/job")
+                .excludePathPatterns("/quest/leader")
                 .excludePathPatterns("/");
     }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/controller/QuestController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/controller/QuestController.java
@@ -45,18 +45,36 @@ public class QuestController {
         return ResponseEntity.ok(new DtoResponse<>(HttpStatus.CREATED, responseProperties.getSuccess(), response));
     }
 
-    @PatchMapping("/job")
-    public ResponseEntity<DtoResponse<QuestResponse>> updateWeekCountJobQuest(@RequestBody QuestRequest.UpdateJobQuest request) {
-        QuestResponse response = questService.updateWeekCountJobQuest(request);
-        return ResponseEntity.ok(new DtoResponse<>(HttpStatus.OK, responseProperties.getSuccess(), response));
-    }
-
     @GetMapping("/job")
     public ResponseEntity<DtoResponse<QuestResponse>> getWeekCountJobQuest(@RequestParam String departmentName,
                                                                            @RequestParam Integer jobGroup,
                                                                            @RequestParam Integer weekCount) {
         QuestRequest.JobQuest request = new QuestRequest.JobQuest(departmentName, jobGroup, weekCount);
         QuestResponse response = questService.getWeekCountJobQuest(request);
+        return ResponseEntity.ok(new DtoResponse<>(HttpStatus.OK, responseProperties.getSuccess(), response));
+    }
+
+    @PatchMapping("/job")
+    public ResponseEntity<DtoResponse<QuestResponse>> updateWeekCountJobQuest(@RequestBody QuestRequest.UpdateJobQuest request) {
+        QuestResponse response = questService.updateWeekCountJobQuest(request);
+        return ResponseEntity.ok(new DtoResponse<>(HttpStatus.OK, responseProperties.getSuccess(), response));
+    }
+
+    @GetMapping("/leader")
+    public ResponseEntity<DtoResponse<QuestResponse>> getLeaderQuest(@RequestParam Integer month,
+                                                                           @RequestParam Integer employeeNum,
+                                                                           @RequestParam String name,
+                                                                           @RequestParam String questName,
+                                                                           @RequestParam String grade,
+                                                                           @RequestParam Integer expAmount) {
+        QuestRequest.LeaderQuest request = new QuestRequest.LeaderQuest(month, employeeNum, name, questName, grade, expAmount);
+        QuestResponse response = questService.getLeaderQuest(request);
+        return ResponseEntity.ok(new DtoResponse<>(HttpStatus.OK, responseProperties.getSuccess(), response));
+    }
+
+    @PatchMapping("/leader")
+    public ResponseEntity<DtoResponse<QuestResponse>> updateLeaderQuest(@RequestBody QuestRequest.UpdateLeaderQuest request) {
+        QuestResponse response = questService.updateLeaderQuest(request);
         return ResponseEntity.ok(new DtoResponse<>(HttpStatus.OK, responseProperties.getSuccess(), response));
     }
 

--- a/myhands/src/main/java/tabom/myhands/domain/quest/dto/QuestRequest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/dto/QuestRequest.java
@@ -52,6 +52,29 @@ public class QuestRequest {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class LeaderQuest {
+        private Integer month;
+        private Integer employeeNum;
+        private String name;
+        private String questName;
+        private String grade;
+        private Integer expAmount;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateLeaderQuest {
+        private Integer month;
+        private String name;
+        private String questName;
+        private String grade;
+        private Integer expAmount;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class QuestCalendar {
         private Long userId;
         private Integer year;

--- a/myhands/src/main/java/tabom/myhands/domain/quest/entity/UserQuest.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/entity/UserQuest.java
@@ -12,6 +12,11 @@ import tabom.myhands.domain.user.entity.User;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(name = "unique_user_quest", columnNames = {"user_id", "quest_id"})
+        }
+)
 public class UserQuest {
 
     @Id

--- a/myhands/src/main/java/tabom/myhands/domain/quest/repository/QuestRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/repository/QuestRepository.java
@@ -16,4 +16,5 @@ public interface QuestRepository extends JpaRepository<Quest, Long> {
                                         @Param("jobGroupNumber") Integer jobGroupNumber,
                                         @Param("weekCount") Integer weekCount);
 
+    Optional<Quest> findQuestByName(String name);
 }

--- a/myhands/src/main/java/tabom/myhands/domain/quest/service/QuestService.java
+++ b/myhands/src/main/java/tabom/myhands/domain/quest/service/QuestService.java
@@ -17,7 +17,11 @@ public interface QuestService {
 
     Quest createWeekCountJobQuest(QuestRequest.JobQuest request);
 
+    QuestResponse getWeekCountJobQuest(QuestRequest.JobQuest request);
+
     QuestResponse updateWeekCountJobQuest(QuestRequest.UpdateJobQuest request);
 
-    QuestResponse getWeekCountJobQuest(QuestRequest.JobQuest request);
+    QuestResponse getLeaderQuest(QuestRequest.LeaderQuest request);
+
+    QuestResponse updateLeaderQuest(QuestRequest.UpdateLeaderQuest request);
 }

--- a/myhands/src/main/java/tabom/myhands/domain/user/repository/UserRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/user/repository/UserRepository.java
@@ -32,4 +32,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findAll();
 
     List<User> findUsersByDepartmentAndJobGroup(Department department, Integer jobGroup);
+
+    Optional<User> findUserByEmployeeNumAndName(Integer employeeNum, String name);
 }


### PR DESCRIPTION
## PR Description :page_facing_up:
 
### 관련 이슈 번호

- #36 
  
### 주요 변경사항
  
- [x] 리더부여 퀘스트 api 생성, 시트 연동
- [x] 경험치 생성 로직에 TODO 표시