### PR TITLE
[BOARD] 게시글 구글 시트 연동

### DIFF
--- a/myhands/.gitignore
+++ b/myhands/.gitignore
@@ -42,3 +42,6 @@ application-jwt.properties
 
 ### firebase ###
 myhandsFirebaseKey.json
+
+### googlet sheet ###
+googleSheetKey.json

--- a/myhands/build.gradle
+++ b/myhands/build.gradle
@@ -42,7 +42,10 @@ dependencies {
 	implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
 
 	implementation 'com.google.firebase:firebase-admin:9.4.2'
-
+	implementation 'com.google.apis:google-api-services-drive:v3-rev20220815-2.0.0'
+	implementation 'com.google.api-client:google-api-client:2.0.0'
+	implementation 'com.google.apis:google-api-services-sheets:v4-rev20220927-2.0.0'
+	implementation 'com.google.auth:google-auth-library-oauth2-http:0.20.0'
 }
 
 tasks.named('test') {

--- a/myhands/src/main/java/tabom/myhands/common/config/WebConfig.java
+++ b/myhands/src/main/java/tabom/myhands/common/config/WebConfig.java
@@ -20,6 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/quest/leader")
                 .excludePathPatterns("/quest/company")
                 .excludePathPatterns("/quest/hr")
+                .excludePathPatterns("/google/*")
                 .excludePathPatterns("/");
     }
 }

--- a/myhands/src/main/java/tabom/myhands/domain/board/entity/Board.java
+++ b/myhands/src/main/java/tabom/myhands/domain/board/entity/Board.java
@@ -36,6 +36,9 @@ public class Board {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
 
+    @Column(name = "google_id")
+    private Long googleId;
+
     public static Board build(BoardRequest.Create request, Long userId) {
         return Board.builder()
                 .userId(userId)
@@ -43,6 +46,20 @@ public class Board {
                 .content(request.getContent())
                 .createdAt(LocalDateTime.now())
                 .build();
+    }
+
+    public static Board googleBoardBuild(BoardRequest.Edit request, Long userId) {
+        return Board.builder()
+                .userId(userId)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .googleId(request.getBoardId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void updateGoogleId(Long googleId) {
+        this.googleId = googleId;
     }
 
     public void edit(BoardRequest.Edit request) {

--- a/myhands/src/main/java/tabom/myhands/domain/board/repository/BoardRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/board/repository/BoardRepository.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 public interface BoardRepository extends JpaRepository<Board, Long> {
     Optional<Board> findByBoardId(Long id);
 
+    Optional<Board> findByGoogleId(Long id);
+
     @Query(value = "SELECT * FROM board ORDER BY created_at DESC LIMIT :size", nativeQuery = true)
     List<Board> findFirstPage(@Param("size") int size);
 
@@ -25,4 +27,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query(value = "SELECT * FROM board WHERE title LIKE CONCAT('%', :word, '%') AND board_id < :lastId ORDER BY created_at DESC LIMIT :size", nativeQuery = true)
     List<Board> findWordLastId(@Param("word") String word, @Param("lastId") Long lastId, @Param("size") int size);
+
+    @Query("SELECT MAX(b.googleId) FROM Board b WHERE b.googleId IS NOT NULL")
+    Long findMaxGoogleId();
 }

--- a/myhands/src/main/java/tabom/myhands/domain/board/service/BoardServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/board/service/BoardServiceImpl.java
@@ -9,6 +9,7 @@ import tabom.myhands.domain.board.dto.BoardRequest;
 import tabom.myhands.domain.board.dto.BoardResponse;
 import tabom.myhands.domain.board.entity.Board;
 import tabom.myhands.domain.board.repository.BoardRepository;
+import tabom.myhands.domain.google.service.GoogleBoardService;
 import tabom.myhands.error.errorcode.BoardErrorCode;
 import tabom.myhands.error.exception.BoardApiException;
 
@@ -20,6 +21,7 @@ public class BoardServiceImpl implements BoardService{
 
     private final BoardRepository boardRepository;
     private final AlarmService alarmService;
+    private final GoogleBoardService googleBoardService;
 
     @Override
     @Transactional
@@ -34,6 +36,7 @@ public class BoardServiceImpl implements BoardService{
 
         Board board = Board.build(requestDto, userId);
         boardRepository.save(board);
+        googleBoardService.createBoardToSheet(board);
         alarmService.createBoardAlarm(board);
     }
 

--- a/myhands/src/main/java/tabom/myhands/domain/google/controller/GoogleBoardController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/google/controller/GoogleBoardController.java
@@ -1,0 +1,29 @@
+package tabom.myhands.domain.google.controller;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tabom.myhands.common.properties.ResponseProperties;
+import tabom.myhands.common.response.MessageResponse;
+import tabom.myhands.domain.board.dto.BoardRequest;
+import tabom.myhands.domain.google.service.GoogleBoardService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/google/board")
+public class GoogleBoardController {
+    private final ResponseProperties responseProperties;
+    private final GoogleBoardService googleBoardService;
+
+    @PostMapping("")
+    public ResponseEntity<MessageResponse> create(@RequestBody BoardRequest.Edit requestDto) throws FirebaseMessagingException {
+        Long userId = 1L;
+        googleBoardService.create(userId, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(MessageResponse.of(HttpStatus.CREATED, responseProperties.getSuccess()));
+    }
+}

--- a/myhands/src/main/java/tabom/myhands/domain/google/service/GoogleBoardService.java
+++ b/myhands/src/main/java/tabom/myhands/domain/google/service/GoogleBoardService.java
@@ -1,0 +1,11 @@
+package tabom.myhands.domain.google.service;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import tabom.myhands.domain.board.dto.BoardRequest;
+import tabom.myhands.domain.board.entity.Board;
+
+public interface GoogleBoardService {
+    void create(Long userId, BoardRequest.Edit requestDto) throws FirebaseMessagingException;
+
+    void createBoardToSheet(Board board);
+}

--- a/myhands/src/main/java/tabom/myhands/domain/google/service/GoogleBoardServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/google/service/GoogleBoardServiceImpl.java
@@ -1,0 +1,101 @@
+package tabom.myhands.domain.google.service;
+
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tabom.myhands.domain.alarm.service.AlarmService;
+import tabom.myhands.domain.board.dto.BoardRequest;
+import tabom.myhands.domain.board.entity.Board;
+import tabom.myhands.domain.board.repository.BoardRepository;
+import tabom.myhands.error.errorcode.BoardErrorCode;
+import tabom.myhands.error.exception.BoardApiException;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.services.sheets.v4.model.AppendValuesResponse;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.*;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleBoardServiceImpl implements GoogleBoardService {
+
+    private static final String SPREADSHEET_ID = "1adSZxf7wF9P6gfMVmu5qGIyl3Yj67Vm_33IA302LhEg"; // 테스트 시트 id
+    private final BoardRepository boardRepository;
+    private final AlarmService alarmService;
+    private static final String APPLICATION_NAME = "myhands"; // Google Sheets 애플리케이션의 이름
+    private static final JacksonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance(); // JSON 데이터를 처리하기 위한 JsonFactory 인스턴스
+    private static final String CREDENTIALS_FILE_PATH = "googleSheetKey.json"; // 인증에 사용되는 JSON 파일 경로 지정(resources 아래 기준)
+    private Sheets sheetsService;
+
+    @Override
+    @Transactional
+    public void create(Long userId, BoardRequest.Edit requestDto) throws FirebaseMessagingException {
+        if (requestDto.getTitle() == null || requestDto.getTitle().isEmpty() ||
+                requestDto.getContent() == null || requestDto.getContent().isEmpty()) {
+            throw new BoardApiException(BoardErrorCode.TITLE_OR_CONTENT_MISSING);
+        }
+
+        Optional<Board> opBoard = boardRepository.findByGoogleId(requestDto.getBoardId());
+        if(opBoard.isPresent()) {
+            Board board = opBoard.get();
+            board.edit(requestDto);
+            boardRepository.save(board);
+        } else {
+            Board board = Board.googleBoardBuild(requestDto, userId);
+            boardRepository.save(board);
+            alarmService.createBoardAlarm(board);
+        }
+    }
+
+    public void createBoardToSheet(Board board) {
+        Long googleId = boardRepository.findMaxGoogleId() + 1;
+        board.updateGoogleId(googleId);
+        boardRepository.save(board);
+
+        List<List<Object>> values = new ArrayList<>();
+        String range = "참고. 게시판!B" + (googleId + 6) + ":D" + (googleId + 6);  // 데이터를 삽입할 범위
+        List<Object> row = Arrays.asList(googleId, board.getTitle(), board.getContent());  // 각 셀에 들어갈 값
+        values.add(row);
+        writeToSheet(SPREADSHEET_ID, range, values);
+    }
+
+    // Sheets 인스턴스 생성 메소드
+    private Sheets getSheetsService() throws IOException, GeneralSecurityException {
+        if (sheetsService == null) {
+            // 권한 지정
+            GoogleCredentials credentials = GoogleCredentials.fromStream(new ClassPathResource(CREDENTIALS_FILE_PATH).getInputStream())
+                    .createScoped(Collections.singletonList("https://www.googleapis.com/auth/spreadsheets"));
+            sheetsService = new Sheets.Builder(GoogleNetHttpTransport.newTrustedTransport(), JSON_FACTORY, new HttpCredentialsAdapter(credentials))
+                    .setApplicationName(APPLICATION_NAME)
+                    .build();
+        }
+        return sheetsService;
+    }
+
+    public void writeToSheet(String spreadsheetId, String range, List<List<Object>> values) {
+        try {
+            Sheets service = getSheetsService();
+            ValueRange body = new ValueRange().setValues(values);
+            AppendValuesResponse result = service.spreadsheets()
+                    .values()
+                    .append(spreadsheetId, range, body)
+                    .setValueInputOption("USER_ENTERED")
+                    .setIncludeValuesInResponse(true)
+                    .execute();
+        } catch (Exception e) {
+            log.error("Failed to write data to the spreadsheet", e);
+            throw new RuntimeException("Failed to write data to the spreadsheet: " + e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
## PR Description :page_facing_up:
 
### 관련 이슈 번호

- #62 
  
### 주요 변경사항
  
- [x] 구글 시트에서 게시글 작성 시 데이터베이스에 반영 및 푸쉬 알람
- [x] 구글 시트에서 게시글 수정 시 데이터베이스에 반영
- [x] 스프링부트 게시글 생성 api 작동 시 구글 시트에 반영
- [x] googleSheetKey.json 파일 추가
  
### 리뷰 요청

- googleId 컬럼이 user 엔티티에 추가되었습니다. 구글 시트에서 게시글 번호입니다!
- googleId 컬럼은 중복되면 문제가 발생합니다.